### PR TITLE
updated version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ClimaX"
-version = "0.1.0"
+version = "0.2.1"
 authors =[
     {name="Tung Nguyen", email="tungnd@g.ucla.edu"},
     {name="Jayesh K. Gupta", email="mail@rejuvyesh.com"}


### PR DESCRIPTION
The version should reflect the latest release so that the output visualised when running `pip install -e .` is consistent.